### PR TITLE
Add transparency to all windows.

### DIFF
--- a/ThirtyDollarGUI/Views/Downloader.axaml
+++ b/ThirtyDollarGUI/Views/Downloader.axaml
@@ -11,7 +11,11 @@
         MinWidth="250"
         MinHeight="350"
         Width="250"
-        Height="350">
+        Height="350"
+        
+        TransparencyLevelHint="AcrylicBlur"
+        Background="Transparent"
+        ExtendClientAreaToDecorationsHint="True">
         
         <Panel>
             <ExperimentalAcrylicBorder IsHitTestVisible="False">

--- a/ThirtyDollarGUI/Views/ExportSettings.axaml
+++ b/ThirtyDollarGUI/Views/ExportSettings.axaml
@@ -11,7 +11,12 @@
         MinHeight="400"
         MinWidth="400"
         Height="400"
-        Width="400">
+        Width="400"
+        
+        TransparencyLevelHint="AcrylicBlur"
+        Background="Transparent"
+        ExtendClientAreaToDecorationsHint="True">
+    
     <Panel>
         <ExperimentalAcrylicBorder IsHitTestVisible="False">
             <ExperimentalAcrylicBorder.Material>

--- a/ThirtyDollarGUI/Views/Greeter.axaml
+++ b/ThirtyDollarGUI/Views/Greeter.axaml
@@ -13,7 +13,6 @@
 
         TransparencyLevelHint="AcrylicBlur"
         Background="Transparent"
-        
         ExtendClientAreaToDecorationsHint="True">
         
     <Panel>

--- a/ThirtyDollarGUI/Views/MainWindow.axaml
+++ b/ThirtyDollarGUI/Views/MainWindow.axaml
@@ -13,7 +13,11 @@
         MinWidth="480"
         Width="480"
         Height="640"
-        services:DialogService.Register="{Binding}">
+        services:DialogService.Register="{Binding}"
+        
+        TransparencyLevelHint="AcrylicBlur"
+        Background="Transparent"
+        ExtendClientAreaToDecorationsHint="True">
 
     <Design.DataContext>
         <vm:MainWindowViewModel/>


### PR DESCRIPTION
This branch adds transparency to all windows on macOS and Windows. The GUI framework we're using (Avalonia UI) doesn't support colored transparency on Linux for now.

Fixes and closes #21