### PR TITLE
Update the Thirty Dollar Visualizer to take advantage of multiple threads.

### DIFF
--- a/ThirtyDollarVisualizer/Audio/BufferHolder.cs
+++ b/ThirtyDollarVisualizer/Audio/BufferHolder.cs
@@ -6,6 +6,10 @@ public readonly struct BufferHolder(Dictionary<string, Dictionary<double, Audibl
 {
     public readonly Dictionary<string, Dictionary<double, AudibleBuffer>> ProcessedBuffers = processedBuffers;
 
+    public BufferHolder() : this(new Dictionary<string, Dictionary<double, AudibleBuffer>>())
+    {
+    }
+
     public AudibleBuffer GetBuffer(string event_name, double event_value)
     {
         return ProcessedBuffers[event_name][event_value];

--- a/ThirtyDollarVisualizer/Audio/SequencePlayer.cs
+++ b/ThirtyDollarVisualizer/Audio/SequencePlayer.cs
@@ -1,4 +1,5 @@
 using ThirtyDollarConverter.Objects;
+using ThirtyDollarParser;
 using ThirtyDollarVisualizer.Audio.FeatureFlags;
 using ThirtyDollarVisualizer.Audio.Null;
 using ThirtyDollarVisualizer.Helpers.Timing;
@@ -7,9 +8,9 @@ namespace ThirtyDollarVisualizer.Audio;
 
 public class SequencePlayer
 {
+    public readonly AudioContext AudioContext = new NullAudioContext();
     protected readonly SeekableStopwatch TimingStopwatch = new();
     protected readonly SemaphoreSlim UpdateLock = new(1);
-    protected readonly AudioContext AudioContext = new NullAudioContext();
     protected readonly Action<string>? Log;
     protected readonly Dictionary<string, Action<Placement, int>> EventActions = new();
     
@@ -339,6 +340,7 @@ public enum PlayerErrors
 
 public struct TimedEvents
 {
+    public Sequence Sequence;
     public Placement[] Placement;
     public int TimingSampleRate;
 }

--- a/ThirtyDollarVisualizer/Audio/SequencePlayer.cs
+++ b/ThirtyDollarVisualizer/Audio/SequencePlayer.cs
@@ -120,6 +120,16 @@ public class SequencePlayer
         await UpdateLock.WaitAsync();
         TimingStopwatch.Seek(milliseconds);
         AlignToTime();
+        if (!EventActions.TryGetValue(string.Empty, out var event_action))
+        {
+            UpdateLock.Release();
+            return;
+        }
+
+        var placement = Events.Placement[PlacementIndex];
+        await Task.Run(() => { event_action.Invoke(placement, (int)placement.SequenceIndex); })
+            .ConfigureAwait(false);
+        
         UpdateLock.Release();
     }
     
@@ -192,15 +202,8 @@ public class SequencePlayer
             
         while (_update_running && !_dead)
         {
-            try
-            {
-                await PlaybackUpdate();
-                await Task.Delay(1);
-            }
-            catch
-            {
-                UpdateLock.Release();
-            }
+            await PlaybackUpdate();
+            await Task.Delay(1);
         }
     }
 

--- a/ThirtyDollarVisualizer/Base Objects/Planes/TexturedPlane.cs
+++ b/ThirtyDollarVisualizer/Base Objects/Planes/TexturedPlane.cs
@@ -1,6 +1,5 @@
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
-using ThirtyDollarVisualizer.Animations;
 using ThirtyDollarVisualizer.Renderer;
 
 namespace ThirtyDollarVisualizer.Objects.Planes;
@@ -56,7 +55,7 @@ public class TexturedPlane : Renderable
 
             var layout = new VertexBufferLayout();
             layout.PushFloat(3); // xyz vertex coords
-            layout.PushFloat(2); // wh vertex coords
+            layout.PushFloat(2); // wh frag coords
             Static_Vao.AddBuffer(Static_Vbo, layout);
 
             Static_Ebo = new BufferObject<uint>(indices, BufferTarget.ElementArrayBuffer);
@@ -74,12 +73,13 @@ public class TexturedPlane : Renderable
             Vao.Bind();
             Ebo.Bind();
 
-            if (_texture == null) return;
+            var texture = _texture;
+            if (texture == null || texture.NeedsLoading())
+            {
+                texture = Texture.Transparent1x1;
+            }
             
-            if (_texture.NeedsLoading())
-                _texture.LoadOpenGLTexture();
-            
-            _texture.Bind();
+            texture.Bind();
             Shader.Use();
             SetShaderUniforms(camera);
 
@@ -108,5 +108,5 @@ public class TexturedPlane : Renderable
         }
     }
 
-    public Texture? GetTexture => _texture;
+    public Texture? GetTexture() => _texture;
 }

--- a/ThirtyDollarVisualizer/Base Objects/Planes/TexturedPlane.cs
+++ b/ThirtyDollarVisualizer/Base Objects/Planes/TexturedPlane.cs
@@ -65,6 +65,8 @@ public class TexturedPlane : Renderable
 
     public override void Render(Camera camera)
     {
+        if (!IsVisible) return;
+        
         lock (LockObject)
         {
             if (Ebo == null || Vao == null) return;
@@ -73,7 +75,7 @@ public class TexturedPlane : Renderable
 
             if (_texture == null) return;
             
-            _texture?.Bind();
+            _texture.Bind();
             Shader.Use();
             SetShaderUniforms(camera);
 

--- a/ThirtyDollarVisualizer/Base Objects/Planes/TexturedPlane.cs
+++ b/ThirtyDollarVisualizer/Base Objects/Planes/TexturedPlane.cs
@@ -74,9 +74,14 @@ public class TexturedPlane : Renderable
             Ebo.Bind();
 
             var texture = _texture;
-            if (texture == null || texture.NeedsLoading())
+            if (texture == null)
             {
                 texture = Texture.Transparent1x1;
+            }
+
+            if (texture.NeedsLoading())
+            {
+                texture.LoadOpenGLTexture();
             }
             
             texture.Bind();

--- a/ThirtyDollarVisualizer/Base Objects/Planes/TexturedPlane.cs
+++ b/ThirtyDollarVisualizer/Base Objects/Planes/TexturedPlane.cs
@@ -1,5 +1,6 @@
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
+using ThirtyDollarVisualizer.Animations;
 using ThirtyDollarVisualizer.Renderer;
 
 namespace ThirtyDollarVisualizer.Objects.Planes;
@@ -74,6 +75,9 @@ public class TexturedPlane : Renderable
             Ebo.Bind();
 
             if (_texture == null) return;
+            
+            if (_texture.NeedsLoading())
+                _texture.LoadOpenGLTexture();
             
             _texture.Bind();
             Shader.Use();

--- a/ThirtyDollarVisualizer/Base Objects/Renderable.cs
+++ b/ThirtyDollarVisualizer/Base Objects/Renderable.cs
@@ -51,7 +51,7 @@ public abstract class Renderable
     /// </summary>
     public bool IsVisible = true;
 
-    private bool IsChild;
+    public bool IsChild;
 
     /// <summary>
     /// Updates the current renderable's model for the MVP rendering method.

--- a/ThirtyDollarVisualizer/Base Objects/Renderable.cs
+++ b/ThirtyDollarVisualizer/Base Objects/Renderable.cs
@@ -46,6 +46,11 @@ public abstract class Renderable
     /// </summary>
     public bool IsBeingUpdated = false;
 
+    /// <summary>
+    /// Sets whether this renderable calls it's render method.
+    /// </summary>
+    public bool IsVisible = true;
+
     private bool IsChild;
 
     /// <summary>

--- a/ThirtyDollarVisualizer/Base Objects/Texture.cs
+++ b/ThirtyDollarVisualizer/Base Objects/Texture.cs
@@ -95,7 +95,7 @@ public class Texture : IDisposable
         var img = texture_data;
         _handle = GL.GenTexture();
         
-        Console.WriteLine($"Loading texture handle: {_handle}");
+        Console.WriteLine($"[Texture Handler] Loading texture handle: {_handle}");
         if (_handle == 0) throw new Exception("Unable to generate texture handle."); 
         Bind();
             

--- a/ThirtyDollarVisualizer/Base Objects/Texture.cs
+++ b/ThirtyDollarVisualizer/Base Objects/Texture.cs
@@ -28,6 +28,7 @@ public class Texture : IDisposable
     public Texture(string path)
     {
         _handle = GL.GenTexture();
+        if (_handle == 0) throw new Exception("Unable to generate texture handle."); 
         Bind();
         
         Stream source;
@@ -57,6 +58,7 @@ public class Texture : IDisposable
     public Texture(Font font, string text, Color? color = null)
     {
         _handle = GL.GenTexture();
+        if (_handle == 0) throw new Exception("Unable to generate texture handle."); 
         Bind();
 
         var options = new TextOptions(font);
@@ -92,6 +94,7 @@ public class Texture : IDisposable
         Width = width;
         Height = height;
         _handle = GL.GenTexture();
+        if (_handle == 0) throw new Exception("Unable to generate texture handle."); 
         Bind();
 
         fixed (void* d = &data[0])

--- a/ThirtyDollarVisualizer/Base Objects/Texture.cs
+++ b/ThirtyDollarVisualizer/Base Objects/Texture.cs
@@ -43,6 +43,9 @@ public class Texture : IDisposable
         }
 
         texture_data = Image.Load<Rgba32>(source);
+        Width = texture_data.Width;
+        Height = texture_data.Height;
+        
         source.Dispose();
     }
 
@@ -55,6 +58,8 @@ public class Texture : IDisposable
         var c_h = Math.Ceiling(rect.Height);
         
         texture_data = new Image<Rgba32>((int) Math.Max(c_w, 1), (int) Math.Max(c_h, 1), Color.Transparent);
+        Width = texture_data.Width;
+        Height = texture_data.Height;
         
         var point = PointF.Empty;
 
@@ -93,11 +98,8 @@ public class Texture : IDisposable
         Console.WriteLine($"Loading texture handle: {_handle}");
         if (_handle == 0) throw new Exception("Unable to generate texture handle."); 
         Bind();
-        
-        Width = img.Width;
-        Height = img.Height;
             
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, img.Width, img.Height, 
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, Width, Height, 
             0, PixelFormat.Rgba, PixelType.UnsignedByte, 0);
 
         img.ProcessPixelRows(accessor =>

--- a/ThirtyDollarVisualizer/Base Objects/Texture.cs
+++ b/ThirtyDollarVisualizer/Base Objects/Texture.cs
@@ -21,16 +21,13 @@ public class Texture : IDisposable
         }
     }
 
-    private readonly int _handle;
+    private int? _handle;
+    private Image<Rgba32>? texture_data;
     public int Width;
     public int Height;
     
     public Texture(string path)
     {
-        _handle = GL.GenTexture();
-        if (_handle == 0) throw new Exception("Unable to generate texture handle."); 
-        Bind();
-        
         Stream source;
 
         if (File.Exists(path))
@@ -45,48 +42,31 @@ public class Texture : IDisposable
             source = stream ?? throw new FileNotFoundException($"Unable to find texture \'{path}\' in assembly or real path.");
         }
 
-        using (var img = Image.Load<Rgba32>(source))
-        {
-            LoadImage(img);
-        }
-
-        SetParameters();
-        
+        texture_data = Image.Load<Rgba32>(source);
         source.Dispose();
     }
 
     public Texture(Font font, string text, Color? color = null)
     {
-        _handle = GL.GenTexture();
-        if (_handle == 0) throw new Exception("Unable to generate texture handle."); 
-        Bind();
-
         var options = new TextOptions(font);
         var rect = TextMeasurer.MeasureSize(text, options);
 
         var c_w = Math.Ceiling(rect.Width);
         var c_h = Math.Ceiling(rect.Height);
         
-        using Image<Rgba32> image = new((int) Math.Max(c_w, 1), (int) Math.Max(c_h, 1), Color.Transparent);
-        if (c_w < 1 || c_h < 1)
-        {
-            LoadImage(image);
-            SetParameters();
-            return;
-        }
+        texture_data = new Image<Rgba32>((int) Math.Max(c_w, 1), (int) Math.Max(c_h, 1), Color.Transparent);
         
         var point = PointF.Empty;
 
         color ??= Color.White;
+
+        var cast_color = (Color) color;
         
-        image.Mutate(x => 
+        texture_data.Mutate(x => 
                 x.DrawText(text, font, Color.Black, point)
-                .GaussianBlur(1)
-                .DrawText(text, font, (Color) color, point)
+                .GaussianBlur(1f)
+                .DrawText(text, font, cast_color, point)
             );
-        
-        LoadImage(image);
-        SetParameters();
     }
 
     public unsafe Texture(Span<byte> data, int width, int height)
@@ -101,16 +81,24 @@ public class Texture : IDisposable
         {
             GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, new IntPtr(d));
         }
-        
-        SetParameters();
     }
 
-    private unsafe void LoadImage(Image<Rgba32> img)
+    private unsafe void LoadImage()
     {
+        if (texture_data is null) throw new Exception("No texture data available.");
+        
+        var img = texture_data;
+        _handle = GL.GenTexture();
+        
+        Console.WriteLine($"Loading texture handle: {_handle}");
+        if (_handle == 0) throw new Exception("Unable to generate texture handle."); 
+        Bind();
+        
         Width = img.Width;
         Height = img.Height;
             
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, img.Width, img.Height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, 0);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba8, img.Width, img.Height, 
+            0, PixelFormat.Rgba, PixelType.UnsignedByte, 0);
 
         img.ProcessPixelRows(accessor =>
         {
@@ -122,6 +110,17 @@ public class Texture : IDisposable
                 }
             }
         });
+        
+        texture_data.Dispose();
+        texture_data = null;
+    }
+
+    public bool NeedsLoading() => !_handle.HasValue;
+
+    public void LoadOpenGLTexture()
+    {
+        LoadImage();
+        SetParameters();
     }
 
     private static void SetParameters()
@@ -138,13 +137,15 @@ public class Texture : IDisposable
 
     public void Bind(TextureUnit textureSlot = TextureUnit.Texture0)
     {
+        if (!_handle.HasValue) return;
         GL.ActiveTexture(textureSlot);
-        GL.BindTexture(TextureTarget.Texture2D, _handle);
+        GL.BindTexture(TextureTarget.Texture2D, _handle.Value);
     }
 
     public void Dispose()
     {
-        GL.DeleteTexture(_handle);
+        if (_handle.HasValue)
+            GL.DeleteTexture(_handle.Value);
         GC.SuppressFinalize(this);
     }
 }

--- a/ThirtyDollarVisualizer/Manager.cs
+++ b/ThirtyDollarVisualizer/Manager.cs
@@ -69,7 +69,6 @@ public class Manager(int width, int height, string title, int? fps = null, Windo
     protected override void OnRenderFrame(FrameEventArgs args)
     {
         RenderBlock.Wait();
-        Context.MakeCurrent();
         
         GL.Clear(ClearBufferMask.ColorBufferBit);
         GL.ClearColor(.0f, .0f, .0f, 1f);
@@ -85,7 +84,6 @@ public class Manager(int width, int height, string title, int? fps = null, Windo
 
     protected override void OnUpdateFrame(FrameEventArgs args)
     {
-        Context.MakeCurrent();
         while (TexturePreloadQueue.TryDequeue(out var texture))
         {
             if (texture.NeedsLoading())

--- a/ThirtyDollarVisualizer/Manager.cs
+++ b/ThirtyDollarVisualizer/Manager.cs
@@ -25,8 +25,7 @@ public class Manager(int width, int height, string title, int? fps = null, Windo
 {
     public readonly List<IScene> Scenes = new();
     public readonly SemaphoreSlim RenderBlock = new(1);
-    private readonly Dictionary<int, IGraphicsContext> GraphicsContexts = new();
-
+    
     public static void CheckErrors()
     {
         ErrorCode errorCode;
@@ -54,9 +53,6 @@ public class Manager(int width, int height, string title, int? fps = null, Windo
         {
             scene.Start();
         }
-
-        var thread_id = Environment.CurrentManagedThreadId;
-        GraphicsContexts.Add(thread_id, Context);
     }
 
     protected override void OnResize(ResizeEventArgs e)
@@ -71,7 +67,7 @@ public class Manager(int width, int height, string title, int? fps = null, Windo
     protected override void OnRenderFrame(FrameEventArgs args)
     {
         RenderBlock.Wait();
-        MakeThreadContextCurrent();
+        Context.MakeCurrent();
         
         GL.Clear(ClearBufferMask.ColorBufferBit);
         GL.ClearColor(.0f, .0f, .0f, 1f);
@@ -134,21 +130,5 @@ public class Manager(int width, int height, string title, int? fps = null, Windo
         {
             scene.Close();
         }
-    }
-
-    public unsafe IGraphicsContext GetGraphicsContext()
-    {
-        var thread_id = Environment.CurrentManagedThreadId;
-        if (GraphicsContexts.TryGetValue(thread_id, out var context)) return context;
-
-        context = new GLFWGraphicsContext(WindowPtr);
-        GraphicsContexts.Add(thread_id, context);
-        return context;
-    }
-
-    public void MakeThreadContextCurrent()
-    {
-        var context = GetGraphicsContext();
-        context.MakeCurrent();
     }
 }

--- a/ThirtyDollarVisualizer/Manager.cs
+++ b/ThirtyDollarVisualizer/Manager.cs
@@ -4,7 +4,6 @@ using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Common.Input;
 using OpenTK.Windowing.Desktop;
 using OpenTK.Windowing.GraphicsLibraryFramework;
-using ThirtyDollarVisualizer.Objects;
 using ThirtyDollarVisualizer.Objects.Text;
 using ThirtyDollarVisualizer.Scenes;
 using ErrorCode = OpenTK.Graphics.OpenGL.ErrorCode;
@@ -26,7 +25,6 @@ public class Manager(int width, int height, string title, int? fps = null, Windo
 {
     public readonly List<IScene> Scenes = new();
     public readonly SemaphoreSlim RenderBlock = new(1);
-    public readonly Queue<Texture> TexturePreloadQueue = new();
     
     public static void CheckErrors()
     {
@@ -84,12 +82,6 @@ public class Manager(int width, int height, string title, int? fps = null, Windo
 
     protected override void OnUpdateFrame(FrameEventArgs args)
     {
-        while (TexturePreloadQueue.TryDequeue(out var texture))
-        {
-            if (texture.NeedsLoading())
-                texture.LoadOpenGLTexture();
-        }
-        
         foreach (var scene in Scenes)
         {
             scene.Update();
@@ -137,10 +129,5 @@ public class Manager(int width, int height, string title, int? fps = null, Windo
         {
             scene.Close();
         }
-    }
-
-    public void QueueTexture(Texture texture)
-    {
-        TexturePreloadQueue.Enqueue(texture);
     }
 }

--- a/ThirtyDollarVisualizer/Objects/SoundRenderable.cs
+++ b/ThirtyDollarVisualizer/Objects/SoundRenderable.cs
@@ -65,7 +65,7 @@ public class SoundRenderable : TexturedPlane
         Fade();
         Expand();
 
-        var old_texture = ValueRenderable.GetTexture;
+        var old_texture = ValueRenderable.GetTexture();
         var texture = generated_textures[_event.PlayTimes.ToString()];
         
         if (_event.PlayTimes == 0)

--- a/ThirtyDollarVisualizer/Program.cs
+++ b/ThirtyDollarVisualizer/Program.cs
@@ -105,6 +105,11 @@ public static class Program
         /*var un30_dollar_application = new UnThirtyDollarApplication(width, height, audio_context);
         manager.Scenes.Add(un30_dollar_application);*/
         
+        if (sequence != null)
+        {
+            
+        }
+        
         manager.Run();
     }
 }

--- a/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
+++ b/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
@@ -22,21 +22,21 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
     private static Texture? MissingTexture;
     private readonly List<Renderable> start_objects = new();
     private readonly List<Renderable> static_objects = new();
-    private Memory<SoundRenderable>  TDW_images;
     private readonly Stopwatch _open_stopwatch = new();
     private readonly Stopwatch _seek_delay_stopwatch = new();
     private readonly Stopwatch _file_update_stopwatch = new();
-
-    private DollarStoreCamera Camera;
+    private readonly DollarStoreCamera Camera;
+    
     private int Width;
     private int Height;
     private int PlayfieldWidth;
+    private Memory<SoundRenderable>  TDW_images;
 
     private ColoredPlane _background = null!;
     private ColoredPlane _flash_overlay = null!;
     private ColoredPlane _visible_area = null!;
-    private Renderable _greeting = null!;
-    private SoundRenderable _drag_n_drop = null!;
+    private Renderable? _greeting;
+    private SoundRenderable? _drag_n_drop;
     
     private const int TimingSampleRate = 100_000;
 
@@ -150,11 +150,11 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
             Value = "DON'T LECTURE ME WITH YOUR THIRTY DOLLAR VISUALIZER"
         };
 
-        _greeting = greeting.WithPosition((Width / 2f, -200f, 0.25f), PositionAlign.Center);
+        _greeting ??= greeting.WithPosition((Width / 2f, -200f, 0.25f), PositionAlign.Center);
         
         start_objects.Add(_greeting);
 
-        if (_sequence_location == null)
+        if (_drag_n_drop == null)
         {
             var dnd_texture = new Texture(greeting_font, "Drop a file on the window to start.");
             _drag_n_drop = new SoundRenderable(dnd_texture,
@@ -164,7 +164,10 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
             _greeting.Children.Add(_drag_n_drop);
             start_objects.Add(_drag_n_drop);
             _drag_n_drop.UpdateModel(false);
-            
+        }
+        
+        if (_sequence_location == null)
+        {
             FinishedInitializing = true;
             return;
         }
@@ -186,7 +189,8 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
     protected override void HandleAfterSequenceUpdate(TimedEvents events)
     {
         FinishedInitializing = false;
-        _drag_n_drop.IsVisible = false;
+        if (_drag_n_drop != null)
+            _drag_n_drop.IsVisible = false;
         Camera.ScrollTo((0,-300,0));
         _background.SetColor(new Vector4(0.21f, 0.22f, 0.24f, 1f));
         

--- a/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
+++ b/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
@@ -544,7 +544,6 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
 
     public void Resize(int w, int h)
     {
-        LeftMargin = (int)((float)Width / 2 - (float) PlayfieldWidth / 2);
         var resize = new Vector2i(w, h);
 
         Camera.Viewport = resize;
@@ -583,6 +582,7 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         
         Width = w;
         Height = h;
+        LeftMargin = (int)((float)Width / 2 - (float) PlayfieldWidth / 2);
         
         var current_update = CurrentResizeFrame = _open_stopwatch.ElapsedMilliseconds;
         

--- a/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
+++ b/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
@@ -25,6 +25,7 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
     private Memory<SoundRenderable>  TDW_images;
     private readonly Stopwatch _open_stopwatch = new();
     private readonly Stopwatch _seek_delay_stopwatch = new();
+    private readonly Stopwatch _file_update_stopwatch = new();
 
     private DollarStoreCamera Camera;
     private int Width;
@@ -85,6 +86,7 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         Camera = new DollarStoreCamera((0,-300f,0), new Vector2i(Width, Height));
         _open_stopwatch.Start();
         _seek_delay_stopwatch.Start();
+        _file_update_stopwatch.Start();
 
         _reset_time = true;
     }
@@ -244,7 +246,6 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         
         Manager.RenderBlock.Wait(Token);
         TDW_images = tdw_images.ToArray();
-        SequencePlayer.Start().GetAwaiter().GetResult();
         FinishedInitializing = true;
         Manager.RenderBlock.Release();
     }
@@ -686,7 +687,11 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
     public void Update()
     {
         if (!FinishedInitializing) return;
-        HandleIfSequenceUpdate();
+        if (_file_update_stopwatch.ElapsedMilliseconds > 250)
+        {
+            HandleIfSequenceUpdate();
+        }
+        
         Camera.Update();
 
         var stopwatch = SequencePlayer.GetTimingStopwatch();

--- a/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
+++ b/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
@@ -191,7 +191,8 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         Manager.RenderBlock.Wait(Token);
         FinishedInitializing = false;
         _drag_n_drop.IsVisible = false;
-        Camera = new DollarStoreCamera((0,-300f,0), new Vector2i(Width, Height));
+        Camera.ScrollTo((0,-300,0));
+        _background.SetColor(new Vector4(0.21f, 0.22f, 0.24f, 1f));
         
         var tdw_images = new List<SoundRenderable>();
         var font_family = Fonts.GetFontFamily();
@@ -210,24 +211,16 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
 
         try
         {
-            foreach (var placement in events.Placement)
+            foreach (var ev in events.Sequence.Events)
             {
-                var ev = placement.Event;
                 if (string.IsNullOrEmpty(ev.SoundEvent) || ev.SoundEvent.StartsWith('#'))
                 {
                     continue;
                 }
 
-                try
-                {
-                    CreateEventRenderable(tdw_images, ev, _texture_cache, wh, flex_box, 
-                        ValueTextCache, _volume_text_cache, font,
-                        volume_color, volume_font);
-                }
-                finally
-                {
-                    Manager.CheckErrors();
-                }
+                CreateEventRenderable(tdw_images, ev, _texture_cache, wh, flex_box,
+                    ValueTextCache, _volume_text_cache, font,
+                    volume_color, volume_font);
             }
 
             var max_decreasing_event = events.Sequence.Events.Where(r => r.SoundEvent is "!stop" or "!loopmany").MaxBy(r => r.Value);
@@ -433,7 +426,8 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         #endregion
         
         tdw_images.Add(plane);
-
+        plane.UpdateModel(false);
+        
         if (ev.SoundEvent is not "!divider") return;
 
         flex_box.NewLine();
@@ -616,6 +610,8 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
                 image.SetTranslation(new_offset);
             }
         }, Token);
+        
+        LeftMargin = (int)((float)Width / 2 - (float) PlayfieldWidth / 2); 
     }
 
     public void Start()
@@ -744,10 +740,6 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
     private void FileDrop(string? location, bool reset_time)
     {
         _reset_time = reset_time;
-        if (reset_time)
-        {
-            Camera = new DollarStoreCamera((0, -300f, 0), (Width, Height));
-        }
         
         var old_location = _sequence_location;
         if (location is not null)

--- a/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
+++ b/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
@@ -100,7 +100,6 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         static_objects.Clear();
         start_objects.Clear();
         
-        MissingTexture ??= new Texture("ThirtyDollarVisualizer.Assets.Textures.action_missing.png");
         if (!UpdatedRenderableScale)
         {
             RenderableSize = (int)(RenderableSize * Scale);
@@ -109,6 +108,11 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         }
 
         Manager = manager;
+        if (MissingTexture is null)
+        {
+            MissingTexture = new Texture("ThirtyDollarVisualizer.Assets.Textures.action_missing.png");
+            Manager.QueueTexture(MissingTexture);
+        }
 
         Log("Loaded sequence and placement.");
 
@@ -140,18 +144,22 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         var font_family = Fonts.GetFontFamily();
         var greeting_font = font_family.CreateFont(36 * Scale, FontStyle.Bold);
 
-        _greeting = new StaticText
+        var greeting = new StaticText
         {
             FontStyle = FontStyle.Bold,
             FontSizePx = 36f * Scale,
             Value = "DON'T LECTURE ME WITH YOUR THIRTY DOLLAR VISUALIZER"
-        }.WithPosition((Width / 2f, - 200f, 0.25f), PositionAlign.Center);
+        };
+        Manager.QueueTexture(greeting.GetTexture()!);
+
+        _greeting = greeting.WithPosition((Width / 2f, -200f, 0.25f), PositionAlign.Center);
         
         start_objects.Add(_greeting);
 
         if (_sequence_location == null)
         {
             var dnd_texture = new Texture(greeting_font, "Drop a file on the window to start.");
+            Manager.QueueTexture(dnd_texture);
             _drag_n_drop = new SoundRenderable(dnd_texture,
                 new Vector3(Width / 2f - dnd_texture.Width / 2f, 0, 0.25f),
                 new Vector2(dnd_texture.Width, dnd_texture.Height));
@@ -188,7 +196,7 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         var tdw_images = new List<SoundRenderable>();
         var font_family = Fonts.GetFontFamily();
         
-        var flex_box = new FlexBox(new Vector2i(LeftMargin + 7, 0),
+        var flex_box = new FlexBox(new Vector2i((int)(LeftMargin + 7 * Scale), 0),
             new Vector2i(PlayfieldWidth + MarginBetweenRenderables, Height), MarginBetweenRenderables);
         var wh = new Vector2i(RenderableSize, RenderableSize);
 
@@ -212,7 +220,8 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
 
                 try
                 {
-                    CreateEventRenderable(tdw_images, ev, _texture_cache, wh, flex_box, ValueTextCache, _volume_text_cache, font,
+                    CreateEventRenderable(tdw_images, ev, _texture_cache, wh, flex_box, 
+                        ValueTextCache, _volume_text_cache, font,
                         volume_color, volume_font);
                 }
                 finally
@@ -231,12 +240,15 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
                 if (ValueTextCache.ContainsKey(search)) continue;
 
                 var texture = new Texture(font, search);
+                Manager.QueueTexture(texture);
                 ValueTextCache.Add(search, texture);
             }
 
             if (!ValueTextCache.ContainsKey("0"))
             {
-                ValueTextCache.Add("0", new Texture(font, "0"));
+                var texture = new Texture(font, "0");
+                Manager.QueueTexture(texture);
+                ValueTextCache.Add("0", texture);
             }
         }
         catch (Exception e)
@@ -283,6 +295,7 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         if (texture == null)
         {
             texture = new Texture(image);
+            Manager.QueueTexture(texture);
             texture_cache.Add(image, texture);
         }
 
@@ -366,6 +379,7 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
             if (value_texture == null)
             {
                 value_texture = new Texture(font, value, volume_color);
+                Manager.QueueTexture(texture);
                 value_text_cache.Add(value, value_texture);
             }
         }
@@ -399,6 +413,7 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
             if (volume_texture == null)
             {
                 volume_texture = new Texture(volume_font, volume_text);
+                Manager.QueueTexture(texture);
                 volume_text_cache.Add(volume_text, volume_texture);
             }
 

--- a/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
+++ b/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
@@ -57,8 +57,8 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
     private float LastBPM = 300f;
     private readonly Dictionary<string, Texture> ValueTextCache = new();
     private bool _reset_time;
-    private Dictionary<string, Texture> _texture_cache;
-    private Dictionary<string, Texture> _volume_text_cache;
+    private Dictionary<string, Texture> _texture_cache = null!;
+    private Dictionary<string, Texture> _volume_text_cache = null!;
     public int RenderableSize { get; set; } = 64;
     public int MarginBetweenRenderables { get; set; } = 12;
     public int ElementsOnSingleLine { get; init; } = 16;
@@ -183,7 +183,6 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         Manager.RenderBlock.Wait(Token);
         FinishedInitializing = false;
         _drag_n_drop.IsVisible = false;
-        Manager.MakeThreadContextCurrent();
         Camera = new DollarStoreCamera((0,-300f,0), new Vector2i(Width, Height));
         
         var tdw_images = new List<SoundRenderable>();
@@ -375,13 +374,14 @@ public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
         {
             var text_position = new Vector3
             {
-                X = plane_position.X + width_height.X / 2f - value_texture.Width / 2f,
-                Y = box_position.Y + RenderableSize - 10f * Scale,
-                Z = box_position.Z
+                X = plane_position.X + width_height.X / 2f,
+                Y = box_position.Y + RenderableSize - MarginBetweenRenderables + 1 * Scale,
+                Z = box_position.Z - 0.1f
             };
-            text_position.Z -= 0.1f;
 
-            var text = new TexturedPlane(value_texture, text_position, (value_texture.Width, value_texture.Height));
+            var text = new TexturedPlane(value_texture, Vector3.Zero, (value_texture.Width, value_texture.Height));
+            text.SetPosition(text_position, PositionAlign.TopCenter);
+            
             plane.SetValueRenderable(text);
             plane.Children.Add(text);
         }

--- a/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
+++ b/ThirtyDollarVisualizer/Scenes/ThirtyDollarApplication.cs
@@ -3,9 +3,7 @@ using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 using SixLabors.Fonts;
-using ThirtyDollarConverter;
 using ThirtyDollarConverter.Objects;
-using ThirtyDollarConverter.Resamplers;
 using ThirtyDollarEncoder.PCM;
 using ThirtyDollarEncoder.Wave;
 using ThirtyDollarParser;
@@ -19,17 +17,14 @@ using ThirtyDollarVisualizer.Objects.Text;
 
 namespace ThirtyDollarVisualizer.Scenes;
 
-public class ThirtyDollarApplication : IScene
+public class ThirtyDollarApplication : ThirtyDollarWorkflow, IScene
 {
     private static Texture? MissingTexture;
     private readonly List<Renderable> start_objects = new();
     private readonly List<Renderable> static_objects = new();
-    private Memory<SoundRenderable> TDW_images;
+    private Memory<SoundRenderable>  TDW_images;
     private readonly Stopwatch _open_stopwatch = new();
     private readonly Stopwatch _seek_delay_stopwatch = new();
-
-    public readonly SequencePlayer SequencePlayer;
-    private readonly AudioContext? _context;
 
     private DollarStoreCamera Camera;
     private int Width;
@@ -40,13 +35,8 @@ public class ThirtyDollarApplication : IScene
     private ColoredPlane _flash_overlay = null!;
     private ColoredPlane _visible_area = null!;
     private Renderable _greeting = null!;
-
-    private Sequence _sequence = null!;
-    private string? _sequence_location;
-    private DateTime _sequence_date_modified = DateTime.MinValue;
-    private readonly Stopwatch _file_modified_stopwatch = new();
+    private SoundRenderable _drag_n_drop = null!;
     
-    private Placement[] _placement = null!;
     private const int TimingSampleRate = 100_000;
 
     private CancellationToken Token => TokenSource.Token;
@@ -67,15 +57,14 @@ public class ThirtyDollarApplication : IScene
     private float LastBPM = 300f;
     private readonly Dictionary<string, Texture> ValueTextCache = new();
     private bool _reset_time;
-
-    public SampleHolder? SampleHolder { get; set; }
+    private Dictionary<string, Texture> _texture_cache;
+    private Dictionary<string, Texture> _volume_text_cache;
     public int RenderableSize { get; set; } = 64;
     public int MarginBetweenRenderables { get; set; } = 12;
     public int ElementsOnSingleLine { get; init; } = 16;
     public CameraFollowMode CameraFollowMode { get; set; } = CameraFollowMode.TDW_Like;
     public string? BackgroundVertexShaderLocation { get; init; }
     public string? BackgroundFragmentShaderLocation { get; init; }
-    public Action<string> Log { get; init; } = log => { Console.WriteLine($"({DateTime.Now:G}): {log}"); };
     public float Scale { get; init; } = 1f;
 
     /// <summary>
@@ -85,21 +74,18 @@ public class ThirtyDollarApplication : IScene
     /// <param name="height">The height of the visualizer.</param>
     /// <param name="sequenceLocation">The location of the sequence.</param>
     /// <param name="audio_context">The audio context the application will use.</param>
-    public ThirtyDollarApplication(int width, int height, string? sequenceLocation, AudioContext? audio_context = null)
+    public ThirtyDollarApplication(int width, int height, string? sequenceLocation, 
+        AudioContext? audio_context = null) : base(audio_context)
     {
         Width = width;
         Height = height;
         _sequence_location = sequenceLocation;
         
-        var camera_position = new Vector3(0,-300f,0);
-        Camera = new DollarStoreCamera(camera_position, new Vector2i(Width, Height));
+        Camera = new DollarStoreCamera((0,-300f,0), new Vector2i(Width, Height));
         _open_stopwatch.Start();
         _seek_delay_stopwatch.Start();
-        _file_modified_stopwatch.Start();
 
         _reset_time = true;
-        _context = audio_context;
-        SequencePlayer = new SequencePlayer();
     }
 
     /// <summary>
@@ -111,6 +97,9 @@ public class ThirtyDollarApplication : IScene
         if (_reset_time)
             SequencePlayer.Stop().GetAwaiter().GetResult();
         
+        static_objects.Clear();
+        start_objects.Clear();
+        
         MissingTexture ??= new Texture("ThirtyDollarVisualizer.Assets.Textures.action_missing.png");
         if (!UpdatedRenderableScale)
         {
@@ -119,16 +108,12 @@ public class ThirtyDollarApplication : IScene
             UpdatedRenderableScale = true;
         }
 
-        var tdw_images = new List<SoundRenderable>();
-        
         Manager = manager;
-
-        #region Textures
 
         Log("Loaded sequence and placement.");
 
         Shader? optional_shader = null;
-        if (BackgroundVertexShaderLocation != null && BackgroundFragmentShaderLocation != null)
+        if (BackgroundVertexShaderLocation is not null && BackgroundFragmentShaderLocation is not null)
         {
             optional_shader = new Shader(BackgroundVertexShaderLocation, BackgroundFragmentShaderLocation);
         }
@@ -148,13 +133,6 @@ public class ThirtyDollarApplication : IScene
 
         LeftMargin = (int)((float)Width / 2 - (float) PlayfieldWidth / 2);
 
-        var flex_box = new FlexBox(new Vector2i(LeftMargin + 7, 0),
-            new Vector2i(PlayfieldWidth + MarginBetweenRenderables, Height), MarginBetweenRenderables);
-        var wh = new Vector2i(RenderableSize, RenderableSize);
-
-        Dictionary<string, Texture> texture_cache = new();
-        Dictionary<string, Texture> volume_text_cache = new();
-
         _visible_area = new ColoredPlane(new Vector4(0, 0, 0, 0.25f), new Vector3(LeftMargin, -Height, 0.5f),
             new Vector2i(PlayfieldWidth, Height * 2));
         static_objects.Add(_visible_area);
@@ -165,96 +143,86 @@ public class ThirtyDollarApplication : IScene
         _greeting = new StaticText
         {
             FontStyle = FontStyle.Bold,
-            FontSizePx = 36f,
+            FontSizePx = 36f * Scale,
             Value = "DON'T LECTURE ME WITH YOUR THIRTY DOLLAR VISUALIZER"
         }.WithPosition((Width / 2f, - 200f, 0.25f), PositionAlign.Center);
         
         start_objects.Add(_greeting);
-        
-        var font = font_family.CreateFont(16 * Scale, FontStyle.Bold);
-
-        var volume_font = font_family.CreateFont(13 * Scale, FontStyle.Bold);
-        var volume_color = new Rgba32(204, 204, 204, 1f);
 
         if (_sequence_location == null)
         {
             var dnd_texture = new Texture(greeting_font, "Drop a file on the window to start.");
-            var drag_n_drop = new SoundRenderable(dnd_texture,
+            _drag_n_drop = new SoundRenderable(dnd_texture,
                 new Vector3(Width / 2f - dnd_texture.Width / 2f, 0, 0.25f),
                 new Vector2(dnd_texture.Width, dnd_texture.Height));
             
-            start_objects.Add(drag_n_drop);
-            drag_n_drop.UpdateModel(false);
+            _greeting.Children.Add(_drag_n_drop);
+            start_objects.Add(_drag_n_drop);
+            _drag_n_drop.UpdateModel(false);
             
             FinishedInitializing = true;
-            _placement = Array.Empty<Placement>();
             return;
         }
-
-        Task.Run(async () =>
-        {
-            var sample_holder = SampleHolder;
-            if (sample_holder == null)
-            {
-                SampleHolder = sample_holder = new SampleHolder();
-                sample_holder.DownloadUpdate = (sample, current, count) =>
-                {
-                    Log($"({current} - {count}): Downloading: \'{sample}\'");
-                };
-
-                await sample_holder.LoadSampleList();
-                sample_holder.PrepareDirectory();
-                await sample_holder.DownloadSamples();
-                sample_holder.LoadSamplesIntoMemory();
-                await sample_holder.DownloadImages();
-            }
-        }, Token).Wait(Token);
         
-        var comp_location = _sequence_location;
         try
         {
-            _sequence = Sequence.FromString(File.ReadAllText(comp_location));
+            UpdateSequence(_sequence_location).GetAwaiter().GetResult();
         }
         catch (Exception e)
         {
             Console.WriteLine(e);
             return;
         }
-        finally
-        {
-            _sequence_date_modified = File.GetLastWriteTime(_sequence_location);
-        }
         
-        tdw_images.EnsureCapacity(_sequence.Events.Length);
-
-        var calculator = new PlacementCalculator(new EncoderSettings
-        {
-            SampleRate = TimingSampleRate,
-            CombineDelayMs = 0,
-            AddVisualEvents = true
-        });
-
-        _placement = calculator.Calculate(_sequence).ToArray();
+        Manager.CheckErrors();
+        FinishedInitializing = true;
+    }
+    
+    protected override void HandleAfterSequenceUpdate(TimedEvents events)
+    {
+        Manager.RenderBlock.Wait(Token);
+        FinishedInitializing = false;
+        _drag_n_drop.IsVisible = false;
+        Manager.MakeThreadContextCurrent();
+        Camera = new DollarStoreCamera((0,-300f,0), new Vector2i(Width, Height));
         
-        var i = 0ul;
-        Task.Run(UpdateChecker, Token);
+        var tdw_images = new List<SoundRenderable>();
+        var font_family = Fonts.GetFontFamily();
+        
+        var flex_box = new FlexBox(new Vector2i(LeftMargin + 7, 0),
+            new Vector2i(PlayfieldWidth + MarginBetweenRenderables, Height), MarginBetweenRenderables);
+        var wh = new Vector2i(RenderableSize, RenderableSize);
+
+        _texture_cache = new Dictionary<string, Texture>();
+        _volume_text_cache = new Dictionary<string, Texture>();
+        
+        var font = font_family.CreateFont(16 * Scale, FontStyle.Bold);
+
+        var volume_font = font_family.CreateFont(13 * Scale, FontStyle.Bold);
+        var volume_color = new Rgba32(204, 204, 204, 1f);
 
         try
         {
-            foreach (var ev in _sequence.Events)
+            foreach (var placement in events.Placement)
             {
+                var ev = placement.Event;
                 if (string.IsNullOrEmpty(ev.SoundEvent) || ev.SoundEvent.StartsWith('#'))
                 {
-                    i++;
                     continue;
                 }
 
-                CreateEventRenderable(tdw_images, ev, texture_cache, wh, flex_box, ValueTextCache, volume_text_cache, font,
-                    volume_color, volume_font);
-                i++;
+                try
+                {
+                    CreateEventRenderable(tdw_images, ev, _texture_cache, wh, flex_box, ValueTextCache, _volume_text_cache, font,
+                        volume_color, volume_font);
+                }
+                finally
+                {
+                    Manager.CheckErrors();
+                }
             }
 
-            var max_decreasing_event = _sequence.Events.Where(r => r.SoundEvent is "!stop" or "!loopmany").MaxBy(r => r.Value);
+            var max_decreasing_event = events.Sequence.Events.Where(r => r.SoundEvent is "!stop" or "!loopmany").MaxBy(r => r.Value);
             
             var textures = max_decreasing_event?.Value ?? 0;
 
@@ -275,58 +243,30 @@ public class ThirtyDollarApplication : IScene
         catch (Exception e)
         {
             Console.WriteLine(e);
-            return;
         }
-        finally
-        {
-            Log("Loaded textures.");
-            Log("Loading sounds.");
-            TDW_images = tdw_images.ToArray();
-            Task.Run(async () => { await LoadAudio(); }, Token).Wait(Token);
-        }
-
-        #endregion
         
-        Manager.CheckErrors();
+        TDW_images = tdw_images.ToArray();
+
+        SequencePlayer.Start().GetAwaiter().GetResult();
         FinishedInitializing = true;
-        return;
-
-        async void UpdateChecker()
-        {
-            var len = (ulong)_sequence.Events.LongLength;
-            var old = 0ul;
-
-            ulong j;
-
-            while ((j = i) < len)
-            {
-                if (j - old > 64)
-                {
-                    Console.Clear();
-                    Console.WriteLine($"({j}) - ({_sequence.Events.LongLength}) ");
-                    old = j;
-                }
-
-                Console.Write(new string('-', (int)(j - old)));
-                await Task.Delay(33, Token);
-            }
-        }
+        Manager.RenderBlock.Release();
+    }
+    
+    protected override void SetSequencePlayerSubscriptions(SequencePlayer player)
+    {
+        player.SubscribeActionToEvent(string.Empty, NormalSubscription);
+        player.SubscribeActionToEvent("!speed", SpeedEventHandler);
+        player.SubscribeActionToEvent("!bg", BackgroundEventHandler);
+        player.SubscribeActionToEvent("!flash", FlashEventHandler);
+        player.SubscribeActionToEvent("!pulse", PulseEventHandler);
+        player.SubscribeActionToEvent("!loopmany", LoopManyEventHandler);
+        player.SubscribeActionToEvent("!stop", StopEventHandler);
+        player.SubscribeActionToEvent("!divider", DividerEventHandler);
     }
 
     /// <summary>
-    /// Creates a Thirty Dollar Website renderable with the texture of the event and it's value and volume as children.
+    /// Creates a Thirty Dollar Website renderable with the texture of the event and its value and volume as children.
     /// </summary>
-    /// <param name="tdw_images">The renderable list you want to add to.</param>
-    /// <param name="ev">The event.</param>
-    /// <param name="texture_cache">The texture cache.</param>
-    /// <param name="wh">The dimensions of a single event.</param>
-    /// <param name="flex_box">A flexbox orderer.</param>
-    /// <param name="value_text_cache">The cache for the textures of the values.</param>
-    /// <param name="volume_text_cache">The cache for the textures of the elements' volumes.</param>
-    /// <param name="font">The font you want to use for the generated textures.</param>
-    /// <param name="volume_color">The color of the volume font.</param>
-    /// <param name="volume_font">The volume font.</param>
-    /// <exception cref="Exception"></exception>
     private void CreateEventRenderable(ICollection<SoundRenderable> tdw_images, Event ev, IDictionary<string, Texture> texture_cache, Vector2i wh,
         FlexBox flex_box,
         IDictionary<string, Texture> value_text_cache, IDictionary<string, Texture> volume_text_cache, Font font, Rgba32 volume_color, Font volume_font)
@@ -431,7 +371,7 @@ public class ThirtyDollarApplication : IScene
             }
         }
 
-        if (value_texture != null)
+        if (value_texture is not null)
         {
             var text_position = new Vector3
             {
@@ -484,69 +424,6 @@ public class ThirtyDollarApplication : IScene
         flex_box.NewLine();
         flex_box.NewLine();
         DividerCount++;
-    }
-
-    private async Task LoadAudio()
-    {
-        if (_context == null) return;
-        var holder = new BufferHolder(new Dictionary<string, Dictionary<double, AudibleBuffer>>());
-        
-        var pcm_encoder = new PcmEncoder(SampleHolder ?? throw new Exception("Sample holder is null."), new EncoderSettings
-        {
-            SampleRate = (uint)_context.SampleRate,
-            Channels = 2,
-            CutDelayMs = 0,
-            Resampler = new LinearResampler()
-        }, Log);
-
-        var (processed_samples, _) = await pcm_encoder.GetAudioSamples(-1, _placement, CancellationToken.None);
-        _context.GlobalVolume = .25f;
-
-        foreach (var ev in processed_samples)
-        {
-            var value = ev.Value;
-            var name = ev.Name;
-
-            if (holder.ProcessedBuffers.TryGetValue(name, out var value_dictionary))
-            {
-                if (value_dictionary.ContainsKey(value)) continue;
-            }
-
-            if (value_dictionary == null)
-            {
-                value_dictionary = new Dictionary<double, AudibleBuffer>();
-                holder.ProcessedBuffers.Add(name, value_dictionary);
-            }
-
-            var sample = _context.GetBufferObject(ev.AudioData, _context.SampleRate);
-            value_dictionary.Add(value, sample);
-        }
-
-        await SequencePlayer.UpdateSequence(holder, new TimedEvents
-        {
-            Placement = _placement,
-            TimingSampleRate = TimingSampleRate
-        });
-        
-        SequencePlayer.ClearSubscriptions();
-        SetSequenceSubscriptions(SequencePlayer);
-        
-        if (_reset_time)
-            await SequencePlayer.Start();
-
-        _reset_time = true;
-    }
-
-    private void SetSequenceSubscriptions(SequencePlayer player)
-    {
-        player.SubscribeActionToEvent(string.Empty, NormalSubscription);
-        player.SubscribeActionToEvent("!speed", SpeedEventHandler);
-        player.SubscribeActionToEvent("!bg", BackgroundEventHandler);
-        player.SubscribeActionToEvent("!flash", FlashEventHandler);
-        player.SubscribeActionToEvent("!pulse", PulseEventHandler);
-        player.SubscribeActionToEvent("!loopmany", LoopManyEventHandler);
-        player.SubscribeActionToEvent("!stop", StopEventHandler);
-        player.SubscribeActionToEvent("!divider", DividerEventHandler);
     }
 
     private SoundRenderable? GetRenderable(Placement placement)
@@ -729,7 +606,14 @@ public class ThirtyDollarApplication : IScene
     public void Start()
     {
         if (_sequence_location == null) return;
-        SequencePlayer.RestartAfter(3000).GetAwaiter().GetResult();
+        SequencePlayer.Stop().GetAwaiter();
+        Task.Run(start, Token);
+        return;
+
+        async void start()
+        {
+            await SequencePlayer.RestartAfter(3000);
+        }
     }
 
     public void Render()
@@ -802,41 +686,15 @@ public class ThirtyDollarApplication : IScene
     public void Update()
     {
         if (!FinishedInitializing) return;
-        HandleSequenceUpdate();
+        HandleIfSequenceUpdate();
         Camera.Update();
 
         var stopwatch = SequencePlayer.GetTimingStopwatch();
-        if (BackingAudio != null)
+        if (BackingAudio is not null)
         {
             BackingAudio.UpdatePlayState(stopwatch.IsRunning);
             BackingAudio.SyncTime(stopwatch.Elapsed);
         }
-    }
-
-    private void HandleSequenceUpdate()
-    {
-        const int update_frequency_ms = 100;
-        if (_file_modified_stopwatch.ElapsedMilliseconds < update_frequency_ms) return;
-        if (_sequence_location == null) return;
-        
-        var m_date = File.GetLastWriteTime(_sequence_location);
-        if (m_date.Equals(_sequence_date_modified)) return;
-
-        Log("Change detected in sequence. Updating.");
-
-        _sequence_date_modified = m_date;
-        
-        Manager.RenderBlock.Wait(Token);
-        try
-        {
-            FileDrop(_sequence_location, false);
-        }
-        finally
-        {
-            Manager.RenderBlock.Release();
-        }
-        
-        _file_modified_stopwatch.Restart();
     }
 
     public void Close()
@@ -874,18 +732,11 @@ public class ThirtyDollarApplication : IScene
         if (reset_time)
         {
             Camera = new DollarStoreCamera((0, -300f, 0), (Width, Height));
-            SequencePlayer.Restart().GetAwaiter().GetResult();
         }
-
-        TDW_images = new Memory<SoundRenderable>();
-        static_objects.Clear();
-        start_objects.Clear();
-
-        var old_location = _sequence_location;
-        _sequence_location = location;
-        Init(Manager);
         
-        Resize(Width, Height);
+        var old_location = _sequence_location;
+        if (location is not null)
+            UpdateSequence(location).GetAwaiter().GetResult();
         
         if (old_location != location || reset_time)
             Start();
@@ -930,7 +781,7 @@ public class ThirtyDollarApplication : IScene
             _seek_delay_stopwatch.Restart();
             var change = elapsed - seek_length;
             
-            var (placement, i) = _placement.Select((placement, i) => (placement , i))
+            var (placement, i) = TimedEvents.Placement.Select((placement, i) => (placement , i))
                 .MinBy(stack => Math.Abs((long) stack.placement.Index * 1000 / TimingSampleRate - change));
             var placement_index = placement?.Index ?? 0;
             
@@ -942,7 +793,7 @@ public class ThirtyDollarApplication : IScene
             _seek_delay_stopwatch.Restart();
             var change = elapsed + seek_length;
             
-            var (placement, i) = _placement.Select((placement, i) => (placement , i))
+            var (placement, i) = TimedEvents.Placement.Select((placement, i) => (placement , i))
                 .MinBy(stack => Math.Abs((long) stack.placement.Index * 1000 / TimingSampleRate - change));
             var placement_index = placement?.Index ?? 0;
             

--- a/ThirtyDollarVisualizer/Scenes/ThirtyDollarWorkflow.cs
+++ b/ThirtyDollarVisualizer/Scenes/ThirtyDollarWorkflow.cs
@@ -10,7 +10,7 @@ public abstract class ThirtyDollarWorkflow(Action<string>? logging_action = null
 {
     protected readonly SequencePlayer SequencePlayer = new();
     protected readonly Action<string> Log = logging_action ?? (log => { Console.WriteLine($"({DateTime.Now:G}): {log}"); });
-    protected SampleHolder? SampleHolder = new();
+    protected SampleHolder? SampleHolder;
     protected TimedEvents TimedEvents = new()
     {
         Placement = Array.Empty<Placement>(),
@@ -45,9 +45,9 @@ public abstract class ThirtyDollarWorkflow(Action<string>? logging_action = null
         SampleHolder.LoadSamplesIntoMemory();
     }
 
-    protected SampleHolder GetSampleHolder()
+    protected async Task<SampleHolder> GetSampleHolder()
     {
-        if (SampleHolder == null) Task.Run(CreateSampleHolder).Wait();
+        if (SampleHolder == null) await CreateSampleHolder();
         return SampleHolder!;
     }
     
@@ -85,8 +85,7 @@ public abstract class ThirtyDollarWorkflow(Action<string>? logging_action = null
         TimedEvents.Placement = placement;
         TimedEvents.Sequence = sequence;
         
-        await CreateSampleHolder();
-        var sample_holder = GetSampleHolder();
+        var sample_holder = await GetSampleHolder().ConfigureAwait(true);
         var buffer_holder = new BufferHolder();
 
         var audio_context = SequencePlayer.GetContext();

--- a/ThirtyDollarVisualizer/Scenes/ThirtyDollarWorkflow.cs
+++ b/ThirtyDollarVisualizer/Scenes/ThirtyDollarWorkflow.cs
@@ -1,0 +1,150 @@
+using ThirtyDollarConverter;
+using ThirtyDollarConverter.Objects;
+using ThirtyDollarConverter.Resamplers;
+using ThirtyDollarParser;
+using ThirtyDollarVisualizer.Audio;
+
+namespace ThirtyDollarVisualizer.Scenes;
+
+public abstract class ThirtyDollarWorkflow(Action<string>? logging_action = null)
+{
+    protected readonly SequencePlayer SequencePlayer = new();
+    protected readonly Action<string> Log = logging_action ?? (log => { Console.WriteLine($"({DateTime.Now:G}): {log}"); });
+    protected SampleHolder? SampleHolder = new();
+    protected TimedEvents TimedEvents = new()
+    {
+        Placement = Array.Empty<Placement>(),
+        TimingSampleRate = 100_000
+    };
+
+    protected string? _sequence_location;
+    protected DateTime _sequence_date_modified = DateTime.MinValue;
+
+    public ThirtyDollarWorkflow(AudioContext? context) : this()
+    {
+        SequencePlayer = new SequencePlayer(context);
+    }
+    
+    /// <summary>
+    /// Creates the sample holder.
+    /// </summary>
+    protected async Task CreateSampleHolder()
+    {
+        SampleHolder = new SampleHolder
+        {
+            DownloadUpdate = (sample, current, count) =>
+            {
+                Log($"({current} - {count}): Downloading: \'{sample}\'");
+            }
+        };
+
+        await SampleHolder.LoadSampleList();
+        SampleHolder.PrepareDirectory();
+        await SampleHolder.DownloadSamples();
+        await SampleHolder.DownloadImages();
+        SampleHolder.LoadSamplesIntoMemory();
+    }
+
+    protected SampleHolder GetSampleHolder()
+    {
+        if (SampleHolder == null) Task.Run(CreateSampleHolder).Wait();
+        return SampleHolder!;
+    }
+    
+    /// <summary>
+    /// This method updates the current sequence.
+    /// </summary>
+    /// <param name="location">The location of the sequence you want to use.</param>
+    public virtual async Task UpdateSequence(string location)
+    {
+        var file_data = await File.ReadAllTextAsync(location);
+        var sequence = Sequence.FromString(file_data);
+        await UpdateSequence(sequence);
+        _sequence_location = location;
+    }
+    
+    /// <summary>
+    /// This method updates the current sequence.
+    /// </summary>
+    /// <param name="sequence">The sequence you want to use.</param>
+    public virtual async Task UpdateSequence(Sequence sequence)
+    {
+        const int update_rate = 100_000;
+        _sequence_location = null;
+
+        await SequencePlayer.Stop();
+
+        var calculator = new PlacementCalculator(new EncoderSettings
+        {
+            SampleRate = update_rate,
+            AddVisualEvents = true
+        });
+
+        var placement = calculator.Calculate(sequence).ToArray();
+        TimedEvents.TimingSampleRate = update_rate;
+        TimedEvents.Placement = placement;
+        TimedEvents.Sequence = sequence;
+        
+        await CreateSampleHolder();
+        var sample_holder = GetSampleHolder();
+        var buffer_holder = new BufferHolder();
+
+        var audio_context = SequencePlayer.GetContext();
+        var pcm_encoder = new PcmEncoder(sample_holder, new EncoderSettings
+        {
+            SampleRate = (uint) audio_context.SampleRate,
+            Channels = 2,
+            Resampler = new LinearResampler()
+        });
+
+        var (samples, _) = await pcm_encoder.GetAudioSamples(-1, placement);
+        
+        foreach (var ev in samples)
+        {
+            var value = ev.Value;
+            var name = ev.Name;
+
+            if (buffer_holder.ProcessedBuffers.TryGetValue(name, out var value_dictionary))
+            {
+                if (value_dictionary.ContainsKey(value)) continue;
+            }
+
+            if (value_dictionary == null)
+            {
+                value_dictionary = new Dictionary<double, AudibleBuffer>();
+                buffer_holder.ProcessedBuffers.Add(name, value_dictionary);
+            }
+
+            var sample = audio_context.GetBufferObject(ev.AudioData, audio_context.SampleRate);
+            value_dictionary.Add(value, sample);
+        }
+        
+        await SequencePlayer.UpdateSequence(buffer_holder, TimedEvents);
+        SequencePlayer.ClearSubscriptions();
+        SetSequencePlayerSubscriptions(SequencePlayer);
+        
+        HandleAfterSequenceUpdate(TimedEvents);
+        await SequencePlayer.Start();
+    }
+
+    /// <summary>
+    /// Called after the sequence has finished loading.
+    /// </summary>
+    /// <param name="events">The events the sequence contains.</param>
+    protected abstract void HandleAfterSequenceUpdate(TimedEvents events);
+    
+    /// <summary>
+    /// Called by the abstract class in order to use the implementation, when the SequencePlayer is created.
+    /// </summary>
+    /// <param name="player">The created SequencePlayer.</param>
+    protected abstract void SetSequencePlayerSubscriptions(SequencePlayer player);
+
+    /// <summary>
+    /// Call this when you want to check if the sequence is updated and you want to update it.
+    /// </summary>
+    protected virtual void HandleIfSequenceUpdate()
+    {
+        if (_sequence_location == null) return;
+        
+    }
+}

--- a/ThirtyDollarVisualizer/Scenes/UnThirtyDollarApplication.cs
+++ b/ThirtyDollarVisualizer/Scenes/UnThirtyDollarApplication.cs
@@ -3,6 +3,8 @@ using OpenTK.Graphics.OpenGL4;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 using SixLabors.Fonts;
+using ThirtyDollarConverter;
+using ThirtyDollarParser;
 using ThirtyDollarVisualizer.Audio;
 using ThirtyDollarVisualizer.Objects;
 using ThirtyDollarVisualizer.Objects.Planes;
@@ -10,9 +12,9 @@ using ThirtyDollarVisualizer.Objects.Text;
 
 namespace ThirtyDollarVisualizer.Scenes;
 
-public class UnThirtyDollarApplication : IScene
+public class UnThirtyDollarApplication : ThirtyDollarWorkflow, IScene
 {
-    public SequencePlayer SequencePlayer;
+    private SampleHolder? sample_holder; 
     private DollarStoreCamera Camera;
     private readonly List<Renderable> static_objects = new();
     private List<MidiKey> key_objects = new();
@@ -29,8 +31,6 @@ public class UnThirtyDollarApplication : IScene
         Width = width;
         Height = height;
         Camera = new DollarStoreCamera(Vector3.Zero, (Width, Height));
-        
-        SequencePlayer = new SequencePlayer(audio_context);
     }
 
     public void Init(Manager manager)
@@ -68,11 +68,9 @@ public class UnThirtyDollarApplication : IScene
         });
     }
 
-    private void SetPianoKeys()
+    private void SetPianoKeys(int min_v = -4, int max_v = 4)
     {
         Manager.RenderBlock.Wait();
-        var min_v = -4;
-        var max_v = 4;
 
         var delta = Math.Abs(min_v) + max_v * 1f;
         var temp_width_single = Width / delta;
@@ -108,6 +106,14 @@ public class UnThirtyDollarApplication : IScene
 
         key_objects = renderables;
         Manager.RenderBlock.Release();
+    }
+    
+    protected override void HandleAfterSequenceUpdate(TimedEvents events)
+    {
+    }
+
+    protected override void SetSequencePlayerSubscriptions(SequencePlayer player)
+    {
     }
 
     public void Start()

--- a/ThirtyDollarVisualizer/Scenes/UnThirtyDollarApplication.cs
+++ b/ThirtyDollarVisualizer/Scenes/UnThirtyDollarApplication.cs
@@ -14,7 +14,6 @@ namespace ThirtyDollarVisualizer.Scenes;
 
 public class UnThirtyDollarApplication : ThirtyDollarWorkflow, IScene
 {
-    private SampleHolder? sample_holder; 
     private DollarStoreCamera Camera;
     private readonly List<Renderable> static_objects = new();
     private List<MidiKey> key_objects = new();

--- a/release.sh
+++ b/release.sh
@@ -37,6 +37,15 @@ zip_releases() {
   done;
 }
 
+if [ "$#" -gt 0 ]; then
+  for arg in "$@"; do
+    if [ "$arg" == "--zip-only" ]; then
+      zip_releases
+      exit
+    fi  
+  done;
+fi
+
 rm -rf "${SCRIPT_DIR:?}/bin"
 mkdir "$SCRIPT_DIR/bin"
 
@@ -50,4 +59,11 @@ publish
 
 create_release_dirs
 copy_releases
-zip_releases
+
+if [ "$#" -gt 0 ]; then
+  for arg in "$@"; do
+    if [ "$arg" == "-z" ]; then
+      zip_releases
+    fi  
+  done;
+fi


### PR DESCRIPTION
1. Abstracted the main workflow of the Thirty Dollar Website to an abstract class which both the ThirtyDollarApplication.cs and UnThirtyDollarApplication.cs use. 

2. Updated the renderer to defer uploading textures, to use only when being shown on the render thread to ensure single-threaded OpenGL interactions.

3. Fixed resizing method.