### PR TITLE
Fix !pulse events.

### DIFF
--- a/ThirtyDollarVisualizer/Objects/DollarStoreCamera.cs
+++ b/ThirtyDollarVisualizer/Objects/DollarStoreCamera.cs
@@ -92,7 +92,8 @@ public sealed class DollarStoreCamera : Camera
         Viewport = camera.Viewport;
         _position = camera.Position;
         projection_matrix = camera.GetProjectionMatrix();
-        SetRenderScale(camera.RenderScale);
+        RenderScale = camera.RenderScale;
+        Scale = camera.Scale;
     }
 
     protected override void SetMatrixValue(float left, float right, float bottom, float top)


### PR DESCRIPTION
The scaling parameters weren't copied to the playfield's camera. This PR fixes that.