### PR TITLE
Fix sequences getting passed to PlacementCalculator methods getting modified.

### DIFF
--- a/ThirtyDollarConverter/PlacementCalculator.cs
+++ b/ThirtyDollarConverter/PlacementCalculator.cs
@@ -73,6 +73,8 @@ public class PlacementCalculator
     public IEnumerable<Placement> CalculateOne(Sequence sequence, ulong? start_time = null)
     {
         if (sequence == null) throw new Exception("Null Sequence");
+        sequence = sequence.Copy();
+        
         var bpm = 300.0;
         var transpose = 0.0;
         var global_volume = 100.0;

--- a/ThirtyDollarConverter/PlacementCalculator.cs
+++ b/ThirtyDollarConverter/PlacementCalculator.cs
@@ -315,11 +315,8 @@ public class PlacementCalculator
                     loop_target = index;
                     break;
                 }
-
-                case "!target":
-                    break;
-
-                case "" or "!flash" or "!bg" or "!combine" or "!startpos" or "!pulse":
+                
+                case "" or "!flash" or "!bg" or "!combine" or "!startpos" or "!pulse" or "!target":
                     break;
 
                 case "!transpose":


### PR DESCRIPTION
Until now sequences passed to PlacementCalculator's CalculateOne method were modified directly. This PR makes it so that the CalculateOne method (which is also called by CalculateMany) makes a local copy of the passed sequence before executing.