### PR TITLE
feat: Update Checker for the Visualizer

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -51,6 +51,18 @@ jobs:
             -p:IncludeNativeLibrariesForSelfExtract=true \
             -o ./bin/${{ matrix.platform }}-${{ matrix.configuration }}
 
+      - name: Write VERSION file
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          # The date is what the in-app update check compares against: a nightly's tag
+          # never changes, so it can't say which of two builds is newer.
+          jq -n --arg tag "nightly-$BRANCH" --arg title "Nightly Build of [$BRANCH]" \
+            --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{tag: $tag, releaseTitle: $title, nightly: true, prerelease: true, date: $date}' \
+            > ./Visualizer/ThirtyDollarVisualizer/VERSION
+          cat ./Visualizer/ThirtyDollarVisualizer/VERSION
+
       - name: Publish ThirtyDollarVisualizer
         env:
           SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -56,12 +56,14 @@ jobs:
         env:
           TAG: ${{ github.event.release.tag_name }}
           TITLE: ${{ github.event.release.name }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
-          if [ -n "$TITLE" ]; then
-            printf '%s (%s)' "$TAG" "$TITLE" > ./Visualizer/ThirtyDollarVisualizer/VERSION
-          else
-            printf '%s' "$TAG" > ./Visualizer/ThirtyDollarVisualizer/VERSION
-          fi
+          # The date is what the in-app update check compares against - see the same step
+          # in dotnet-desktop.yml.
+          jq -n --arg tag "$TAG" --arg title "$TITLE" --argjson prerelease "$PRERELEASE" \
+            --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{tag: $tag, releaseTitle: $title, nightly: false, prerelease: $prerelease, date: $date}' \
+            > ./Visualizer/ThirtyDollarVisualizer/VERSION
           cat ./Visualizer/ThirtyDollarVisualizer/VERSION
 
       - name: Publish ThirtyDollarVisualizer

--- a/ThirtyDollarTools.slnx
+++ b/ThirtyDollarTools.slnx
@@ -30,6 +30,7 @@
   <Folder Name="/Visualizer/">
     <Project Path="Visualizer/Playground/Playground.csproj"/>
     <Project Path="Visualizer/Shared/Shared.csproj"/>
+    <Project Path="Visualizer/Shared.Tests/Shared.Tests.csproj"/>
     <Project Path="Visualizer/ThirtyDollarVisualizer/ThirtyDollarVisualizer.csproj"/>
   </Folder>
   <Folder Name="/Visualizer/Scenes/">

--- a/Visualizer/Scenes/HomeScene/Home.cs
+++ b/Visualizer/Scenes/HomeScene/Home.cs
@@ -3,6 +3,7 @@ using OpenTK.Mathematics;
 using OpenTK.Windowing.Common.Input;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 using Shared;
+using Shared.Updates;
 using Sundex.Components.Abstractions;
 using Sundex.Engine;
 using Sundex.Engine.Renderer.Abstract.Extensions;
@@ -24,8 +25,12 @@ public class Home : Scene
     private readonly TextBuffer _versionBuffer;
     private readonly TextSlice _versionNote;
 
+    private readonly string _versionText;
+
     private CursorType _cursorType = CursorType.Default;
+    private float _height;
     private Vector2 _lastScale = Vector2.One;
+    private bool _updateNoteShown;
 
     public Home(Game game, string version) : base(game)
     {
@@ -47,20 +52,25 @@ public class Home : Scene
             () => { Game.SceneManager.TransitionTo("editor"); },
             () => { Game.SceneManager.TransitionTo("settings"); });
 
-        _versionBuffer = new TextBuffer(_context.TextProvider, _context.DeleteQueue);
-        _versionNote = _versionBuffer.GetTextSlice(
-                $"""
-                 Check regularly for updates at:
-                 https://github.com/t1stm/ThirtyDollarTools
+        _height = clientSize.Y;
+        _versionText =
+            $"""
+             Check regularly for updates at:
+             https://github.com/t1stm/ThirtyDollarTools
 
-                 Current Version: {version}
-                 """,
+             Current Version: {version}
+             """;
+
+        _versionBuffer = new TextBuffer(_context.TextProvider, _context.DeleteQueue);
+        _versionNote = _versionBuffer.GetTextSlice(_versionText,
                 (value, buffer, range) => new TextSlice(buffer, range)
                 {
                     Value = value,
                     FontSize = 14
-                })
-            .WithPosition((10, clientSize.Y, 0), PositionAlign.Bottom | PositionAlign.Left);
+                },
+                // Room for the update line, which arrives later - a slice can't grow.
+                _versionText.Length + 256)
+            .WithPosition((10, _height, 0), PositionAlign.Bottom | PositionAlign.Left);
     }
 
     public override void Initialize(InitArguments initArguments)
@@ -85,6 +95,15 @@ public class Home : Scene
     {
         _cursorType = CursorType.Default;
         _homeInterface.Update(_context);
+
+        // The check runs on the loading screen, but it's over the network - it can land
+        // after this scene is built, so the note is written when it does.
+        if (!_updateNoteShown && UpdateChecker.Available is { } release)
+        {
+            _updateNoteShown = true;
+            _versionNote.Value = $"{_versionText}\nNew Version Available: {release.TagName} {release.HtmlUrl}";
+            _versionNote.SetPosition((10, _height, 0), PositionAlign.Bottom | PositionAlign.Left);
+        }
 
         var cursor = _cursorType switch
         {
@@ -114,6 +133,7 @@ public class Home : Scene
         _camera.Viewport = new Vector2i((int)width, (int)height);
         _camera.UpdateMatrix();
         _context.PixelScale = _lastScale;
+        _height = height;
 
         _homeInterface.Resize();
         _versionNote.SetPosition((10, height, 0), PositionAlign.Bottom | PositionAlign.Left);

--- a/Visualizer/Scenes/LoadingScene/Loader.cs
+++ b/Visualizer/Scenes/LoadingScene/Loader.cs
@@ -6,6 +6,7 @@ using OpenTK.Windowing.Common.Input;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 using Shared;
 using Shared.Audio;
+using Shared.Updates;
 using Sundex.Components.Abstractions;
 using Sundex.Engine;
 using Sundex.Engine.Asset_Management;
@@ -13,6 +14,7 @@ using Sundex.Engine.Renderer.Abstract;
 using Sundex.Engine.Renderer.Attributes;
 using Sundex.Engine.Scenes;
 using Sundex.Engine.Scenes.Arguments;
+using VisualizerScene.Settings;
 
 namespace LoadingScene;
 
@@ -27,13 +29,21 @@ public class Loader : Scene, IGamePreloadable
 
     private readonly LoaderInterface _loaderInterface;
     private readonly ThirtyDollarDownloader _thirtyDollarDownloader;
+    private readonly VisualizerSettings _settings;
+    private readonly VersionInfo? _version;
     private bool _autoLoadStarted;
     private CursorType _cursorType = CursorType.Default;
     private Vector2 _lastScale = Vector2.One;
     private IProgressReport _progressReport = new NotStartedReport();
 
-    public Loader(Game game, AudioContext? audioContext) : base(game)
+    /// <summary>True once the update prompt is out of the way - nothing loads before then.</summary>
+    private bool _updatePromptAnswered;
+
+    public Loader(Game game, AudioContext? audioContext, VisualizerSettings settings, VersionInfo? version) : base(game)
     {
+        _settings = settings;
+        _version = version;
+
         var clientSize = game.ClientSize;
         if (game.TryGetScreenScale(out var scaleX, out var scaleY))
             _lastScale = new Vector2(scaleX, scaleY);
@@ -59,6 +69,53 @@ public class Loader : Scene, IGamePreloadable
         _thirtyDollarDownloader.OnLoadSound = sound => _background.AddSound(sound);
 
         _loaderInterface = new LoaderInterface(_context, () => _thirtyDollarDownloader.Load());
+        SetUpUpdatePrompt();
+    }
+
+    /// <summary>
+    ///     Shows the opt-in question on the first run, and otherwise starts the check the user
+    ///     already agreed to. A build with no VERSION date (a developer build) is never asked:
+    ///     there is no build date to call a release newer than, so the answer couldn't be used.
+    /// </summary>
+    private void SetUpUpdatePrompt()
+    {
+        _updatePromptAnswered = _settings.UpdateCheckAsked || _version?.Date is null;
+        if (_updatePromptAnswered)
+        {
+            _loaderInterface.UpdatePrompt.Visible = false;
+            if (_settings.CheckForUpdates)
+                UpdateChecker.Start(_version, _settings.UpdateIncludePrereleases,
+                    _settings.UpdateIncludeNightlies, Logger);
+            return;
+        }
+
+        _loaderInterface.MainView.Visible = false;
+
+        // Default to the channel this build came from: a prerelease ticks prereleases, and a
+        // nightly ticks both (the nightly workflow marks its releases prerelease as well).
+        _loaderInterface.IncludePrereleases.Checked = _version?.Prerelease ?? false;
+        _loaderInterface.IncludeNightlies.Checked = _version?.Nightly ?? false;
+
+        _loaderInterface.UpdateDecline.OnClick = _ => AnswerUpdatePrompt(false);
+        _loaderInterface.UpdateOptIn.OnClick = _ => AnswerUpdatePrompt(true);
+    }
+
+    private void AnswerUpdatePrompt(bool optIn)
+    {
+        _settings.UpdateIncludePrereleases = _loaderInterface.IncludePrereleases.Checked;
+        _settings.UpdateIncludeNightlies = _loaderInterface.IncludeNightlies.Checked;
+        _settings.CheckForUpdates = optIn;
+        // Last, because every setter writes the settings file: this one is what stops the
+        // question from being asked again.
+        _settings.UpdateCheckAsked = true;
+
+        _loaderInterface.UpdatePrompt.Visible = false;
+        _loaderInterface.MainView.Visible = true;
+        _updatePromptAnswered = true;
+
+        if (optIn)
+            UpdateChecker.Start(_version, _settings.UpdateIncludePrereleases,
+                _settings.UpdateIncludeNightlies, Logger);
     }
 
     public Action<ThirtyDollarWorkflow>? OnFinish { get; set; }
@@ -101,7 +158,9 @@ public class Loader : Scene, IGamePreloadable
         _background.Update();
         _cursorType = CursorType.Default;
 
-        if (!_autoLoadStarted)
+        // Nothing loads while the update prompt is up - the sounds are usually already
+        // there, and the automatic load below would otherwise run straight past the question.
+        if (_updatePromptAnswered && !_autoLoadStarted)
         {
             _autoLoadStarted = true;
             Task.Run(async () =>

--- a/Visualizer/Scenes/LoadingScene/Scenes/Layout/LoaderInterface.snx.csx
+++ b/Visualizer/Scenes/LoadingScene/Scenes/Layout/LoaderInterface.snx.csx
@@ -1,4 +1,5 @@
 using Sundex.Components.Bars;
+using Sundex.Components.Inputs;
 using Sundex.Components.Labels;
 using Sundex.Components.Panels;
 
@@ -11,3 +12,12 @@ context.Label = context.Component.RegisteredIDs["loader-label"] as Label ?? thro
 
 var button = context.Component.RegisteredIDs["start-button"] as Button ?? throw new Exception("Button not found");
 button.OnClick = _ => context.OnClickAction();
+
+// The update prompt's handles - Loader.cs wires its two buttons, since what they do is
+// settings work rather than interface work.
+context.MainView = context.Component.GetID<FlexPanel>("main-view");
+context.UpdatePrompt = context.Component.GetID<FlexPanel>("update-prompt");
+context.IncludePrereleases = context.Component.GetID<Checkbox>("include-prereleases");
+context.IncludeNightlies = context.Component.GetID<Checkbox>("include-nightlies");
+context.UpdateDecline = context.Component.GetID<Button>("update-decline");
+context.UpdateOptIn = context.Component.GetID<Button>("update-opt-in");

--- a/Visualizer/Scenes/LoadingScene/Scenes/Layout/LoaderInterface.snx.ss
+++ b/Visualizer/Scenes/LoadingScene/Scenes/Layout/LoaderInterface.snx.ss
@@ -29,6 +29,74 @@ id main-view {
     border-radius = 16;
 }
 
+// The first-run update opt-in, in main-view's place. Same box as the loader panel, but
+// opaque - it is a question, not a status readout. Colors are the editor's palette
+// (Scenes/Styles/Theme.snx.ss over there); that sheet can't be imported across
+// assemblies, so the values are literal here, as everything else in this file is.
+id update-prompt {
+    anchor-x = "center";
+    anchor-y = "center";
+    x = 50%;
+    y = 50%;
+
+    width = 480px;
+    height = auto;
+
+    padding = 24;
+    spacing = 14;
+    direction = "vertical";
+    horizontal-align = "start";
+
+    background = "#16161e";
+    border-radius = 16;
+}
+
+id update-title {
+    font-size = 24;
+    font-color = "#7aa2f7";
+    font-weight = "bold";
+}
+
+id update-message {
+    font-size = 15;
+}
+
+// The trailing button row: horizontal and flush right, against the vertical default
+// the `flex` rule at the bottom of this sheet sets.
+id update-actions {
+    width = 100%;
+    height = 36;
+    direction = "horizontal";
+    horizontal-align = "end";
+    vertical-align = "center";
+    padding = 0;
+    spacing = 10;
+}
+
+// Standalone rather than a base class plus a modifier: state overrides resolve to the
+// first class that declares them, so a modifier's hover would lose to the base's.
+class prompt-button {
+    font-size = 14;
+    height = 36;
+    border-radius = 6;
+    background = "#33344a";
+
+    state[hovered] = {
+        background = "#3f4160";
+    }
+}
+
+class prompt-button-primary {
+    font-size = 14;
+    height = 36;
+    border-radius = 6;
+    background = "#4c6bcc";
+
+    state[hovered] = {
+        background = "#6b82c4";
+    }
+}
+
 id loader-title {
     font-size = 32;
     font-color = "#7aa2f7";

--- a/Visualizer/Scenes/LoadingScene/Scenes/Layout/LoaderInterface.snx.xml
+++ b/Visualizer/Scenes/LoadingScene/Scenes/Layout/LoaderInterface.snx.xml
@@ -12,6 +12,25 @@
         <panel class="background-gradients" id="grad-5"/>
       </panel>
 
+      <!-- Shown instead of main-view on the first run; Loader.cs swaps the two once the
+           question is answered. -->
+      <flex id="update-prompt">
+        <label id="update-title" value="Update Checker"/>
+        <label id="update-message" value="Do you want to check for updates at the GitHub repository?"/>
+
+        <checkbox id="include-prereleases" value="Include Prereleases"/>
+        <checkbox id="include-nightlies" value="Include Nightlies"/>
+
+        <flex id="update-actions">
+          <button id="update-decline" class="prompt-button">
+            <label value="Don't ask again"/>
+          </button>
+          <button id="update-opt-in" class="prompt-button-primary">
+            <label value="Opt-in"/>
+          </button>
+        </flex>
+      </flex>
+
       <flex id="main-view">
         <label id="loader-title" value="Thirty Dollar Visualizer"/>
         <label id="loader-label" value="Ready to load"/>

--- a/Visualizer/Scenes/LoadingScene/Scenes/LoaderInterface.cs
+++ b/Visualizer/Scenes/LoadingScene/Scenes/LoaderInterface.cs
@@ -4,6 +4,7 @@ using OpenTK.Mathematics;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 using Sundex.Components.Abstractions;
 using Sundex.Components.Bars;
+using Sundex.Components.Inputs;
 using Sundex.Components.Labels;
 using Sundex.Components.Panels;
 using Sundex.Engine.Asset_Management.Types.Asset;
@@ -29,7 +30,9 @@ public class LoaderInterface
         });
 
         Component = sundexContext.NewComponent(componentSource.Value);
-        sundexContext.RunLogicAndVerify(Component, () => RootPanel, () => ProgressBar, () => Label);
+        sundexContext.RunLogicAndVerify(Component, () => RootPanel, () => ProgressBar, () => Label,
+            () => MainView, () => UpdatePrompt, () => IncludePrereleases, () => IncludeNightlies,
+            () => UpdateDecline, () => UpdateOptIn);
         RootPanel.DrawTo(context);
     }
 
@@ -42,6 +45,20 @@ public class LoaderInterface
     [SetFromLogic] public ProgressBar ProgressBar { get; set; } = null!;
 
     [SetFromLogic] public Label Label { get; set; } = null!;
+
+    /// <summary>The loading readout and its start button - hidden while the update prompt is up.</summary>
+    [SetFromLogic] public FlexPanel MainView { get; set; } = null!;
+
+    /// <summary>The first-run update opt-in; <see cref="LoadingScene.Loader" /> owns what its buttons do.</summary>
+    [SetFromLogic] public FlexPanel UpdatePrompt { get; set; } = null!;
+
+    [SetFromLogic] public Checkbox IncludePrereleases { get; set; } = null!;
+
+    [SetFromLogic] public Checkbox IncludeNightlies { get; set; } = null!;
+
+    [SetFromLogic] public Button UpdateDecline { get; set; } = null!;
+
+    [SetFromLogic] public Button UpdateOptIn { get; set; } = null!;
 
     public void Resize()
     {

--- a/Visualizer/Scenes/VisualizerScene/Settings/VisualizerSettings.cs
+++ b/Visualizer/Scenes/VisualizerScene/Settings/VisualizerSettings.cs
@@ -56,6 +56,31 @@ public class VisualizerSettings(Action modifiedCallback)
         set => SetAndCallModified(out field, value);
     } = true;
 
+    /// <summary>Whether the loader has already asked about update checking. False means "first run".</summary>
+    public bool UpdateCheckAsked
+    {
+        get;
+        set => SetAndCallModified(out field, value);
+    }
+
+    public bool CheckForUpdates
+    {
+        get;
+        set => SetAndCallModified(out field, value);
+    }
+
+    public bool UpdateIncludePrereleases
+    {
+        get;
+        set => SetAndCallModified(out field, value);
+    }
+
+    public bool UpdateIncludeNightlies
+    {
+        get;
+        set => SetAndCallModified(out field, value);
+    }
+
 
     private void SetAndCallModified<T>(out T obj, T value)
     {

--- a/Visualizer/Scenes/VisualizerScene/Visualizer.cs
+++ b/Visualizer/Scenes/VisualizerScene/Visualizer.cs
@@ -11,7 +11,6 @@ using Shared.Renderer.Settings;
 using Sundex.Components.Abstractions;
 using Sundex.Engine;
 using Sundex.Engine.Asset_Management;
-using Sundex.Engine.Asset_Management.Types.Asset;
 using Sundex.Engine.Renderer.Abstract;
 using Sundex.Engine.Renderer.Abstract.Extensions;
 using Sundex.Engine.Renderer.Attributes;
@@ -58,16 +57,6 @@ public class Visualizer : Scene, IGamePreloadable
 
     private ulong _updateId;
     private int _width;
-
-    /// <summary>Reads the embedded "VERSION" assembly file, or "Developer Build" when it's absent.</summary>
-    public static string GetVersion(IAssetProvider assetProvider)
-    {
-        var info = new AssetInfo { Location = "VERSION", Storage = StorageLocation.Assembly };
-        if (!assetProvider.Query<AssetStream, AssetInfo>(info)) return "Developer Build";
-
-        using var reader = new StreamReader(assetProvider.Load<AssetStream, AssetInfo>(info).Stream);
-        return reader.ReadToEnd().Trim();
-    }
 
     /// <summary>
     ///     Creates a TDW sequence visualizer.

--- a/Visualizer/Shared.Tests/Shared.Tests.csproj
+++ b/Visualizer/Shared.Tests/Shared.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/Visualizer/Shared.Tests/UpdateCheckerTests.cs
+++ b/Visualizer/Shared.Tests/UpdateCheckerTests.cs
@@ -1,0 +1,76 @@
+using Shared.Updates;
+
+namespace Shared.Tests;
+
+/// <summary>
+///     Which release the update note offers, given the build and the two channel opt-ins.
+///     Only the picking is covered - the fetch around it is one HTTP call in a try/catch.
+/// </summary>
+public class UpdateCheckerTests
+{
+    private static readonly DateTimeOffset BuildDate = new(2026, 8, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static readonly VersionInfo Stable = new("v1.1.6", "Release", false, false, BuildDate);
+
+    private static readonly GitHubRelease[] Releases =
+    [
+        Release("v1.1.5", -3, false), // predates the build
+        Release("v1.1.7", 1, false),
+        Release("v1.1.8-prerelease-1", 2, true),
+        Release("nightly-master", 3, true),
+        Release("nightly-some-feature", 4, true)
+    ];
+
+    /// <param name="daysFromBuild">Release age relative to the build - negative is older.</param>
+    private static GitHubRelease Release(string tag, int daysFromBuild, bool prerelease, bool draft = false)
+    {
+        return new GitHubRelease(tag, $"https://example.invalid/{tag}", prerelease, draft,
+            BuildDate.AddDays(daysFromBuild));
+    }
+
+    [Fact]
+    public void StableOnlySkipsPrereleasesAndNightlies()
+    {
+        Assert.Equal("v1.1.7", UpdateChecker.PickNewer(Releases, Stable, false, false)?.TagName);
+    }
+
+    [Fact]
+    public void PrereleasesOptInTakesTheNewerPrerelease()
+    {
+        Assert.Equal("v1.1.8-prerelease-1", UpdateChecker.PickNewer(Releases, Stable, true, false)?.TagName);
+    }
+
+    [Fact]
+    public void NightliesOptInTakesMasterButNeverAnotherBranch()
+    {
+        Assert.Equal("nightly-master", UpdateChecker.PickNewer(Releases, Stable, true, true)?.TagName);
+    }
+
+    [Fact]
+    public void ANightlyBuildIsOfferedItsOwnBranch()
+    {
+        var build = new VersionInfo("nightly-some-feature", null, true, true, BuildDate);
+        Assert.Equal("nightly-some-feature", UpdateChecker.PickNewer(Releases, build, true, true)?.TagName);
+    }
+
+    [Fact]
+    public void NothingOlderThanTheBuildIsOffered()
+    {
+        GitHubRelease[] onlyOlder = [Release("v1.1.5", -3, false)];
+        Assert.Null(UpdateChecker.PickNewer(onlyOlder, Stable, true, true));
+    }
+
+    [Fact]
+    public void DraftsAreIgnored()
+    {
+        GitHubRelease[] drafted = [Release("v2.0.0", 5, false, true)];
+        Assert.Null(UpdateChecker.PickNewer(drafted, Stable, true, true));
+    }
+
+    [Fact]
+    public void ADeveloperBuildHasNothingToCompareAgainst()
+    {
+        var noDate = Stable with { Date = null };
+        Assert.Null(UpdateChecker.PickNewer(Releases, noDate, true, true));
+    }
+}

--- a/Visualizer/Shared/Updates/UpdateChecker.cs
+++ b/Visualizer/Shared/Updates/UpdateChecker.cs
@@ -1,0 +1,93 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Serilog;
+
+namespace Shared.Updates;
+
+/// <summary>One GitHub release, cut down to the fields the update notice needs.</summary>
+public sealed record GitHubRelease(
+    string TagName,
+    string HtmlUrl,
+    bool Prerelease,
+    bool Draft,
+    DateTimeOffset CreatedAt)
+{
+    /// <summary>The nightly workflow tags every branch's build "nightly-{branch}".</summary>
+    public bool IsNightly => TagName.StartsWith("nightly-");
+}
+
+/// <summary>
+///     Opt-in check of the repository's releases, started once by the loader and read by the
+///     home screen. Fire and forget: a failed check leaves <see cref="Available" /> null and
+///     the version note unchanged.
+/// </summary>
+public static class UpdateChecker
+{
+    private const string Repository = "t1stm/ThirtyDollarTools";
+    private const string ReleasesUrl = $"https://api.github.com/repos/{Repository}/releases?per_page=30";
+
+    // GitHub's fields are snake_case, so this can't be Sundex's camelCase SerializerOptions.
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+    /// <summary>The newer release the check found, or null while none is known.</summary>
+    public static GitHubRelease? Available { get; private set; }
+
+    /// <summary>
+    ///     Starts the check in the background. Releases are compared by date rather than by
+    ///     version: a nightly's tag never changes, so its tag says nothing about which build
+    ///     is newer, while the build date written into VERSION does.
+    /// </summary>
+    public static void Start(VersionInfo? build, bool prereleases, bool nightlies, ILogger logger)
+    {
+        // No build date means a developer build (or a VERSION from before the date was
+        // written) - there is nothing to call a release newer than.
+        if (build?.Date is not { } buildDate) return;
+
+        Task.Run(async () =>
+        {
+            try
+            {
+                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+                client.DefaultRequestHeaders.UserAgent.ParseAdd("ThirtyDollarVisualizer");
+
+                var releases = await client.GetFromJsonAsync<GitHubRelease[]>(ReleasesUrl, Options) ?? [];
+                Available = PickNewer(releases, build, prereleases, nightlies);
+
+                if (Available != null)
+                    logger.Information("A newer release is available: {Tag}", Available.TagName);
+            }
+            catch (Exception e)
+            {
+                logger.Warning(e, "Failed to check {Repository} for updates.", Repository);
+            }
+        });
+    }
+
+    /// <summary>
+    ///     The newest release that this build's channel opt-ins accept and that was created
+    ///     after this build, or null when there's nothing newer.
+    /// </summary>
+    public static GitHubRelease? PickNewer(IEnumerable<GitHubRelease> releases, VersionInfo build,
+        bool prereleases, bool nightlies)
+    {
+        if (build.Date is not { } buildDate) return null;
+
+        return releases
+            .Where(release => !release.Draft && release.CreatedAt > buildDate)
+            .Where(release => Wanted(release, build, prereleases, nightlies))
+            .MaxBy(release => release.CreatedAt);
+    }
+
+    private static bool Wanted(GitHubRelease release, VersionInfo build, bool prereleases, bool nightlies)
+    {
+        // Some other branch's nightly isn't an update to anything: only master's counts,
+        // plus the branch this build itself came from.
+        if (release.IsNightly)
+            return nightlies && (release.TagName == build.Tag || release.TagName == "nightly-master");
+
+        return !release.Prerelease || prereleases;
+    }
+}

--- a/Visualizer/Shared/Updates/VersionInfo.cs
+++ b/Visualizer/Shared/Updates/VersionInfo.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Sundex.Engine.Asset_Management;
+using Sundex.Engine.Asset_Management.Types.Asset;
+using Sundex.Engine.Common;
+
+namespace Shared.Updates;
+
+/// <summary>
+///     The JSON contents of the embedded "VERSION" file, written by the release workflows.
+///     Lives here rather than next to a scene because every scene that shows or checks the
+///     version can see Shared, and none of them can see each other.
+/// </summary>
+public sealed record VersionInfo(
+    string Tag,
+    string? ReleaseTitle,
+    bool Nightly,
+    bool Prerelease,
+    DateTimeOffset? Date)
+{
+    public const string DeveloperBuild = "Developer Build";
+
+    /// <summary>What the home screen's version note shows.</summary>
+    public string Display => string.IsNullOrWhiteSpace(ReleaseTitle) ? Tag : $"{Tag} - {ReleaseTitle}";
+
+    /// <summary>
+    ///     Reads the embedded "VERSION" asset, or null when it's absent or unreadable - that is,
+    ///     when this build didn't come out of a workflow.
+    /// </summary>
+    public static VersionInfo? Read(IAssetProvider assetProvider)
+    {
+        var info = new AssetInfo { Location = "VERSION", Storage = StorageLocation.Assembly };
+        if (!assetProvider.Query<AssetStream, AssetInfo>(info)) return null;
+
+        try
+        {
+            using var stream = assetProvider.Load<AssetStream, AssetInfo>(info).Stream;
+            return JsonSerializer.Deserialize<VersionInfo>(stream, SerializerOptions.Json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/Visualizer/ThirtyDollarVisualizer/Program.cs
+++ b/Visualizer/ThirtyDollarVisualizer/Program.cs
@@ -17,6 +17,7 @@ using Serilog.Templates.Themes;
 using SettingsScene;
 using Shared;
 using Shared.Audio;
+using Shared.Updates;
 using Shared.Audio.BASS;
 using Shared.Audio.Null;
 using Shared.Audio.OpenAL;
@@ -159,10 +160,11 @@ if (game.TryGetScreenScale(out var horizontal_scale, out var vertical_scale) &&
 
 game.Enqueue(instance =>
 {
+    var version = VersionInfo.Read(instance.AssetProvider);
     instance.SceneManager.LoadScene<Loader>("loader",
-        _ => new Loader(instance, audio_context)
+        _ => new Loader(instance, audio_context, settings, version)
         {
-            OnFinish = workflow => { OnLoadHandler(instance, workflow, sequence, greeting, scale); }
+            OnFinish = workflow => { OnLoadHandler(instance, workflow, version, sequence, greeting, scale); }
         });
 });
 
@@ -171,13 +173,14 @@ game.Run();
 
 return;
 
-static void OnLoadHandler(Game game, ThirtyDollarWorkflow workflow,
+static void OnLoadHandler(Game game, ThirtyDollarWorkflow workflow, VersionInfo? version,
     string? sequence, string? greeting, float? scale)
 {
     // preload all scenes in memory (inefficient i know, but leads to better UX)
     game.Enqueue(instance =>
     {
-        instance.SceneManager.LoadScene<Home>("home", _ => new Home(instance, Visualizer.GetVersion(instance.AssetProvider)));
+        instance.SceneManager.LoadScene<Home>("home",
+            _ => new Home(instance, version?.Display ?? VersionInfo.DeveloperBuild));
 
         instance.SceneManager.LoadScene<Visualizer>("visualizer", _ =>
             new Visualizer(instance, SettingsHandler.Settings, workflow, [sequence])


### PR DESCRIPTION
Checks whether a new release has been made after the one that is currently running. Has filters for Prereleases and Nightlies, and preselects those based on whether the user is already running one.